### PR TITLE
Add return statement after final scan on libvirt-based.

### DIFF
--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -424,7 +424,7 @@ class ProfileRunner(GenericRunner):
             logging.info("Rebooting domain '{0}' before final scan."
                          .format(self.environment.domain_name))
             self.environment.reboot()
-        GenericRunner.final(self)
+        return GenericRunner.final(self)
 
     def make_oscap_call(self):
         self.prepare_online_scanning_arguments()

--- a/tests/ssg_test_suite/profile.py
+++ b/tests/ssg_test_suite/profile.py
@@ -29,8 +29,11 @@ class ProfileChecker(ssg_test_suite.oscap.Checker):
             self.test_env, profile, self.datastream, self.benchmark_id)
 
         for stage in ("initial", "remediation", "final"):
-            logging.info("Evaluation of profile {0} ({1} stage).".format(profile, stage))
             result = runner.run_stage(stage)
+            if result:
+                logging.info("Evaluation of the profile has passed: {0} ({1} stage).".format(profile, stage))
+            else:
+                logging.error("Evaluation of the profile has failed: {0} ({1} stage).".format(profile, stage))
 
 
 def perform_profile_check(options):


### PR DESCRIPTION
How it looks like with the actual changes.

```
Setting console output to log level INFO
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - Logging into /home/ggasparb/workspace/github/content/tests/logs/profile-custom-2020-03-17-1710/test_suite.log
INFO - Evaluation of the profile has passed: xccdf_org.ssgproject.content_profile_ospp (initial stage).
INFO - Evaluation of the profile has passed: xccdf_org.ssgproject.content_profile_ospp (remediation stage).
INFO - Rebooting domain 'test-suite-rhel8' before final scan.
INFO - Evaluation of the profile has passed: xccdf_org.ssgproject.content_profile_ospp (final stage).
```